### PR TITLE
modelform_defines_fields import fix

### DIFF
--- a/app_data/admin.py
+++ b/app_data/admin.py
@@ -2,8 +2,8 @@ from functools import partial
 
 try:
     # django 1.7
-    from django.contrib.admin.utils import flatten_fieldsets
     from django.forms.models import modelform_defines_fields
+    from django.contrib.admin.utils import flatten_fieldsets
 except ImportError:
     from django.contrib.admin.util import flatten_fieldsets
 from django.contrib.admin.options import ModelAdmin, InlineModelAdmin

--- a/app_data/admin.py
+++ b/app_data/admin.py
@@ -95,6 +95,6 @@ class AppDataInlineModelAdmin(AppDataAdminMixin, InlineModelAdmin):
 class AppDataStackedInline(AppDataInlineModelAdmin):
     template = 'admin/edit_inline/stacked.html'
 
-class AddDataTabularInline(AppDataInlineModelAdmin):
+class AppDataTabularInline(AppDataInlineModelAdmin):
     template = 'admin/edit_inline/tabular.html'
 

--- a/app_data/admin.py
+++ b/app_data/admin.py
@@ -2,12 +2,12 @@ from functools import partial
 
 try:
     # django 1.7
-    from django.forms.models import modelform_defines_fields
     from django.contrib.admin.utils import flatten_fieldsets
 except ImportError:
     from django.contrib.admin.util import flatten_fieldsets
 from django.contrib.admin.options import ModelAdmin, InlineModelAdmin
 from django import forms
+from django.forms.models import modelform_defines_fields
 
 from app_data.forms import multiform_factory, multiinlineformset_factory, MultiForm
 

--- a/app_data/registry.py
+++ b/app_data/registry.py
@@ -1,3 +1,7 @@
+import copy_reg
+from app_data.containers import AppDataContainerFactory
+copy_reg.pickle(AppDataContainerFactory, lambda adcf: (dict, (adcf.serialize(), )))
+
 class NamespaceConflict(Exception):
     pass
 

--- a/app_data/registry.py
+++ b/app_data/registry.py
@@ -1,7 +1,3 @@
-import copy_reg
-from app_data.containers import AppDataContainerFactory
-copy_reg.pickle(AppDataContainerFactory, lambda adcf: (dict, (adcf.serialize(), )))
-
 class NamespaceConflict(Exception):
     pass
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,14 @@
+checkout:
+  post:
+    - git submodule sync
+    - git submodule update --init
+    - git clone git@github.com:WhiskeyMedia/scout.git scout.git
+dependencies:
+  override:
+
+  cache_directories:
+    - venv/src
+    - ~/.pip/cache
+test:
+  override:
+#    - python setup.py test

--- a/test_app_data/admin.py
+++ b/test_app_data/admin.py
@@ -1,10 +1,10 @@
 from django.contrib.admin import site
 
-from app_data.admin import AppDataModelAdmin, AddDataTabularInline
+from app_data.admin import AppDataModelAdmin, AppDataTabularInline
 
 from .models import Article, Author
 
-class AuthorInline(AddDataTabularInline):
+class AuthorInline(AppDataTabularInline):
     model = Author
     declared_fieldsets = [
         ('Personal', {'fields': [('personal.first_name', 'personal.last_name')]})


### PR DESCRIPTION
Moved the import of `modelform_defines_fields` out of the try/except for Django 1.7 so later on the use of `modelform_defines_fields` will succeed in Django 1.6.4 (and likely earlier).