### PR TITLE
MAINT(Setup): Remove south from setup requires as it breaks virtualen…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ f.close()
 
 install_requires = [
     'Django>=1.4.10',
-    'south>=0.7',
 ]
 test_requires = [
     'nose',


### PR DESCRIPTION
Hi,

I suggest to remove south from install requirements as it breaks virtualenv when the package is used with django >= 1.7.

Regards,