### PR TITLE
Use callable instead of string for default AppData field kwarg.

### DIFF
--- a/app_data/fields.py
+++ b/app_data/fields.py
@@ -40,7 +40,7 @@ class AppDataDescriptor(Creator):
 class AppDataField(TextField):
     def __init__(self, *args, **kwargs):
         self.app_registry = kwargs.pop('app_registry', app_registry)
-        kwargs.setdefault('default', '{}')
+        kwargs.setdefault('default', dict)
         kwargs.setdefault('editable', False)
         super(AppDataField, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
This fixes ``Django 1.8`` and ``Python >=3.3`` cases for data migrations (which I encountered).

Example of an issue can be found here: https://travis-ci.org/aldryn/aldryn-newsblog/jobs/99583826#L1048

     File "./aldryn_newsblog/migrations/0006_default_newsblog_config.py", line 68, in create_default_newsblog_config
        app_config.save()
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/django/db/models/base.py", line 734, in save
        force_update=force_update, update_fields=update_fields)
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/django/db/models/base.py", line 762, in save_base
        updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/django/db/models/base.py", line 824, in _save_table
        for f in non_pks]
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/django/db/models/base.py", line 824, in <listcomp>
        for f in non_pks]
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/django/db/models/fields/__init__.py", line 684, in pre_save
        return getattr(model_instance, self.attname)
      File "/home/travis/build/aldryn/aldryn-newsblog/.tox/py34-dj18-postgres-cms31/lib/python3.4/site-packages/app_data/fields.py", line 27, in __get__
        value._instance = instance
    AttributeError: 'bytes' object has no attribute '_instance'

Root cause was that initial Django migration saved not really appropriate value for AppData field default https://github.com/aldryn/aldryn-newsblog/blob/ada9f93a73f61974e0bf3fe63d6dd495cc5416e0/aldryn_newsblog/migrations/0001_initial.py#L114

The solution was to change default value in that migration to be callable, which I think should be done in the package itself on the first place.